### PR TITLE
Handle speclj error results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject speclj-junit "0.0.10"
+(defproject speclj-junit "0.0.11-SNAPSHOT"
   :description "JUnit xml reporter for the speclj testing framework"
   :url "https://github.com/julias-shaw/speclj-junit"
   :scm {:name "git"


### PR DESCRIPTION
So that he original error is not missed for instance for compilation errors .

Eg. We had compilation error in our project and our Jenkins build failed, but got to log only:
Unknown result type: class speclj.results.ErrorResult

and no test errors.
