### PR TITLE
Updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # speclj-growl
 
-speclj-junit is a plugin for [speclj](http://speclj.com/) that formats output using ant's junit xml format. This format is commonly used by continuous integration tools.
+`speclj-junit` is a plugin for [speclj](http://speclj.com/) that formats output using ant's junit XML format. This format is commonly used by continuous integration tools.
 
 ## Installation
 
 Add the following to your project.clj under the :dev profile:
 
-    :dependencies [[speclj-junit "0.0.10"]]
+    :dependencies [[speclj-junit "0.0.11"]]
 
-Speclj 2.7.x or later is required.
+Speclj 3.3.x or later is required.
 
 ## Usage
 
@@ -28,6 +28,6 @@ Many thanks to Paul Gross for his [speclj-growl](https://github.com/pgr0ss/specl
 
 ## License
 
-Copyright (C) 2015 Julias Shaw
+Copyright (C) 2015-2016 Julias Shaw
 
 Distributed under the The MIT License.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject speclj-junit "0.0.10"
-  :description "JUnit xml reporter for the speclj testing framework"
+(defproject speclj-junit "0.0.11"
+  :description "JUnit XML reporter for the speclj testing framework"
   :url "https://github.com/julias-shaw/speclj-junit"
   :scm {:name "git"
         :url "https://github.com/julias-shaw/speclj-junit"}
@@ -8,12 +8,13 @@
   :signing {:gpg-key "D5935FCC"}
   :deploy-repositories [["clojars" {:creds :gpg}]]
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure  "1.8.0"]
                  [org.clojure/data.xml "0.0.8"]
-                 [clj-time "0.9.0"]]
+                 [clj-time             "0.13.0"]]
   :profiles {
     :dev {
-      :plugins [[speclj "2.7.2"]]
-      :dependencies [[speclj "2.7.2"]
+      :plugins [[speclj       "3.3.2"]
+                [lein-ancient "0.6.10"]]
+      :dependencies [[speclj       "3.3.2"]
                      [speclj-junit "0.0.10"]]
       :test-paths ["spec/"]}})

--- a/spec/speclj/report/junit_spec.clj
+++ b/spec/speclj/report/junit_spec.clj
@@ -73,7 +73,7 @@
   (it "report-runs"
    (let [_ (report-runs @reporter [(pass-result (new-characteristic "passing spec name" nil) 1.00040)
                                    (pending-result (new-characteristic "pending spec name" nil) 1.00050 "Not yet implemented")
-                                   (fail-result (new-characteristic "failing spec name" nil) 1.00060 (speclj.platform/new-failure "Typo"))])
+                                   (fail-result (new-characteristic "failing spec name" nil) 1.00060 (speclj.core/-new-failure "Typo"))])
          output (junit-xml-as-string)]
      (should= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><testsuites><testsuite name=\"speclj\" errors=\"0\" skipped=\"1\" tests=\"3\" failures=\"1\" time=\"3.00150\" timestamp=\"1972-04-19T07:23:06.025Z\"><testcase classname=\"passing spec name\" name=\"passing spec name\" time=\"1.00040\"></testcase><testcase classname=\"pending spec name\" name=\"pending spec name\" time=\"1.00050\"><skipped></skipped></testcase><testcase classname=\"failing spec name\" name=\"failing spec name\" time=\"1.00060\"><failure message=\"test failure\">Typo</failure></testcase></testsuite></testsuites>"
               output)))
@@ -86,5 +86,3 @@
 
   )
  )
-
-


### PR DESCRIPTION
Hi @julias-shaw I've updated dependencies and also accounted for the fact that `speclj.platform/new-failure` has moved to `speclj.core/-new-failure`; I created a candidate v0.0.11 jar artifact and checked it into a local Maven repo and run `lein spec -f junit` against it successfully, so you should be fine to push this update to Clojars. Thanks!